### PR TITLE
fixed leave_order() bug

### DIFF
--- a/utilities/database_reader.py
+++ b/utilities/database_reader.py
@@ -17,7 +17,7 @@ def num_leaves(forest):
         Returns:
             (list(int)): Number of leaves encountered in any tree.
     '''
-    num_leaves = [len(msa_converter.leave_order(t)) for t in forest]
+    num_leaves = [len(msa_converter.leaf_order(t)) for t in forest]
 
     return num_leaves
 


### PR DESCRIPTION
There is no function leave_order() in msa_converter. I changed the name to leaf_order().